### PR TITLE
(PIPELINES-1145) Avoid stack overflow by checking GuiceWebServer requ…

### DIFF
--- a/distelli-webserver/src/main/java/com/distelli/webserver/GuiceWebServer.java
+++ b/distelli-webserver/src/main/java/com/distelli/webserver/GuiceWebServer.java
@@ -39,6 +39,14 @@ public class GuiceWebServer implements Runnable {
         if ( LOG.isDebugEnabled() ) {
             LOG.debug("Dispatching to static servlet {} with response={}", req.getRequestURI(), res);
         }
+        // The default servlet likes to forward requests which will result
+        // in a stack overflow. Avoid this:
+        if ( null == req.getAttribute(GuiceWebServer.class.getName()) ) {
+            req.setAttribute(GuiceWebServer.class.getName(), Boolean.TRUE);
+        } else {
+            res.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
         try {
             req.getServletContext()
                 .getNamedDispatcher(STATIC_SERVLET_NAME)


### PR DESCRIPTION
…est attribute.

If that attribute is already set, send a 404 response. This situation
occurs if the default servlet tries to send the "welcome page" when it
detects that a directory exists for the specified request URI.